### PR TITLE
Adds auto switching based on a .node-version file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ PREFIX ?= /usr/local
 SHARE_DIR := $(PREFIX)/share
 CHNODE_SHARE_DIR := $(SHARE_DIR)/chnode
 CHNODE_SHARE_SOURCES := chnode.sh
+CHNODE_SHARE_AUTO_SOURCES := auto.sh
 CHNODE_DOC_DIR := $(SHARE_DIR)/doc/chnode
 CHNODE_DOC_SOURCES := CHANGELOG.md LICENSE.txt README.md
 
@@ -80,6 +81,7 @@ benchmark:
 install:
 	mkdir -p "$(DESTDIR)$(CHNODE_SHARE_DIR)"
 	cp $(CHNODE_SHARE_SOURCES) "$(DESTDIR)$(CHNODE_SHARE_DIR)/"
+	cp $(CHNODE_SHARE_AUTO_SOURCES) "$(DESTDIR)$(CHNODE_SHARE_DIR)/"
 	mkdir -p "$(DESTDIR)$(CHNODE_DOC_DIR)"
 	cp $(CHNODE_DOC_SOURCES) "$(DESTDIR)$(CHNODE_DOC_DIR)/"
 
@@ -110,6 +112,6 @@ Targets:
 
   benchmark           Run benchmarks with SHELL you choose (usage: \`make benchmark SHELL=bash\`) (select: BM_FILES=benchmark/*-bm.sh)
 
-  install             Copy chnode.sh and its documentation to PREFIX directory
-  uninstall           Remove chnode.sh and its documentation from PREFIX directory
+  install             Copy chnode.sh and auto.sh and its documentation to PREFIX directory
+  uninstall           Remove chnode.sh and auto.sh and its documentation from PREFIX directory
 endef

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To read more about the design rationale and a comparison to [nvm] and
 * Selects Node.js version for a shell session by updating the `PATH`
   environment variable. Version switching is independent per shell
   session.
+* Optional automatic version switching based on a `.node-version` file in your project directory.
 * Small feature set by design, making the tool very fast to load.
 * Each Node.js version has its own set of global npm packages.
 * Allows accessing man pages for the selected Node.js version and its
@@ -91,6 +92,11 @@ Execute `source` command to load chnode functions:
 
 ``` bash
 source chnode.sh
+```
+
+For automatic version switching:
+``` bash
+source auto.sh
 ```
 
 You may append the command above into your bash init script,

--- a/README.md
+++ b/README.md
@@ -94,10 +94,20 @@ Execute `source` command to load chnode functions:
 source chnode.sh
 ```
 
-For automatic version switching:
+For automatic version switching also source the auto script:
+
 ``` bash
 source auto.sh
 ```
+
+To set a default node version for a project, add your `.node-version` file to the root directory.
+
+```bash
+cd awesome-node-project/
+echo "node-8.1.0" > .node-version
+```
+
+You can set a default for your whole system by adding `.node-version` to your home directory.
 
 You may append the command above into your bash init script,
 `~/.bashrc`.

--- a/auto.sh
+++ b/auto.sh
@@ -1,0 +1,33 @@
+unset NODE_AUTO_VERSION
+
+function chnode_auto() {
+	local dir="$PWD/" version
+
+	until [[ -z "$dir" ]]; do
+		dir="${dir%/*}"
+
+		if { read -r version <"$dir/.node-version"; } 2>/dev/null || [[ -n "$version" ]]; then
+			version="${version%%[[:space:]]}"
+
+			if [[ "$version" == "$node_AUTO_VERSION" ]]; then return
+			else
+				node_AUTO_VERSION="$version"
+				chnode "$version"
+				return $?
+			fi
+		fi
+	done
+
+	if [[ -n "$NODE_AUTO_VERSION" ]]; then
+		chnode_reset
+		unset NODE_AUTO_VERSION
+	fi
+}
+
+if [[ -n "$ZSH_VERSION" ]]; then
+	if [[ ! "$preexec_functions" == *chnode_auto* ]]; then
+		preexec_functions+=("chnode_auto")
+	fi
+elif [[ -n "$BASH_VERSION" ]]; then
+	trap '[[ "$BASH_COMMAND" != "$PROMPT_COMMAND" ]] && chnode_auto' DEBUG
+fi

--- a/auto.sh
+++ b/auto.sh
@@ -9,9 +9,9 @@ function chnode_auto() {
 		if { read -r version <"$dir/.node-version"; } 2>/dev/null || [[ -n "$version" ]]; then
 			version="${version%%[[:space:]]}"
 
-			if [[ "$version" == "$node_AUTO_VERSION" ]]; then return
+			if [[ "$version" == "$NODE_AUTO_VERSION" ]]; then return
 			else
-				node_AUTO_VERSION="$version"
+				NODE_AUTO_VERSION="$version"
 				chnode "$version"
 				return $?
 			fi

--- a/auto.sh
+++ b/auto.sh
@@ -1,4 +1,4 @@
-unset NODE_AUTO_VERSION
+unset CHNODE_AUTO_VERSION
 
 function chnode_auto() {
 	local dir="$PWD/" version
@@ -9,18 +9,18 @@ function chnode_auto() {
 		if { read -r version <"$dir/.node-version"; } 2>/dev/null || [[ -n "$version" ]]; then
 			version="${version%%[[:space:]]}"
 
-			if [[ "$version" == "$NODE_AUTO_VERSION" ]]; then return
+			if [[ "$version" == "$CHNODE_AUTO_VERSION" ]]; then return
 			else
-				NODE_AUTO_VERSION="$version"
+				CHNODE_AUTO_VERSION="$version"
 				chnode "$version"
 				return $?
 			fi
 		fi
 	done
 
-	if [[ -n "$NODE_AUTO_VERSION" ]]; then
+	if [[ -n "$CHNODE_AUTO_VERSION" ]]; then
 		chnode_reset
-		unset NODE_AUTO_VERSION
+		unset CHNODE_AUTO_VERSION
 	fi
 }
 

--- a/support/fixture.sh
+++ b/support/fixture.sh
@@ -32,7 +32,6 @@ fixture_make_default_nodes() {
     [[ -z $1 ]] && echo "fixture_make_default_nodes(): expects dir as first parameter" && return 1
 
     fixture_make_nodes_dir "$1" \
-                           node-11.5.0 \
                            node-10.11.0 \
                            node-9.11.2 \
                            node-9.11.2-rc1 \

--- a/support/fixture.sh
+++ b/support/fixture.sh
@@ -2,11 +2,17 @@
 
 fixture_make_default_dir() {
     __FIXTURE_DEFAULT_DIR=$(mktemp -d /tmp/chnode-fixture.XXXXXX)
+}
+
+fixture_make_default_auto_dir() {
     __FIXTURE_DEFAULT_AUTO_DIR=$(mktemp -d /tmp/chnode-auto-fixture.XXXXXX)
 }
 
 fixture_delete_default_dir() {
     [[ -n ${__FIXTURE_DEFAULT_DIR:-} ]] && rm -rf "$__FIXTURE_DEFAULT_DIR"
+}
+
+fixture_delete_default_auto_dir() {
     [[ -n ${__FIXTURE_DEFAULT_AUTO_DIR:-} ]] && rm -rf "$__FIXTURE_DEFAULT_AUTO_DIR"
 }
 

--- a/support/fixture.sh
+++ b/support/fixture.sh
@@ -2,10 +2,12 @@
 
 fixture_make_default_dir() {
     __FIXTURE_DEFAULT_DIR=$(mktemp -d /tmp/chnode-fixture.XXXXXX)
+    __FIXTURE_DEFAULT_AUTO_DIR=$(mktemp -d /tmp/chnode-auto-fixture.XXXXXX)
 }
 
 fixture_delete_default_dir() {
     [[ -n ${__FIXTURE_DEFAULT_DIR:-} ]] && rm -rf "$__FIXTURE_DEFAULT_DIR"
+    [[ -n ${__FIXTURE_DEFAULT_AUTO_DIR:-} ]] && rm -rf "$__FIXTURE_DEFAULT_AUTO_DIR"
 }
 
 fixture_make_nodes_dir() {
@@ -30,9 +32,32 @@ fixture_make_default_nodes() {
     [[ -z $1 ]] && echo "fixture_make_default_nodes(): expects dir as first parameter" && return 1
 
     fixture_make_nodes_dir "$1" \
+                           node-11.5.0 \
                            node-10.11.0 \
                            node-9.11.2 \
                            node-9.11.2-rc1 \
                            node-8.1.0 \
                            iojs-3.3.1
+}
+
+fixture_make_default_auto_test_dirs() {
+    [[ -z $1 ]] && echo "fixture_make_default_auto_test_dirs(): expects dir as first parameter" && return 1
+    fixture_make_auto_test_dirs "$1" \
+                           sub_dir\
+                           modified_version\
+                           bad\
+                           sub_versioned\
+}
+
+fixture_make_auto_test_dirs() {
+  [[ -z $1 ]] && echo "fixture_make_auto_test_dir(): expects dir as first parameter" && return 1
+
+    local dir=$1
+    shift
+
+    local name
+    for name in "$@"; do
+        mkdir -p "$dir/$name"
+        chmod 755 "$dir/$name"
+    done
 }

--- a/support/fixture.sh
+++ b/support/fixture.sh
@@ -46,7 +46,7 @@ fixture_make_default_auto_test_dirs() {
                            sub_dir\
                            modified_version\
                            bad\
-                           sub_versioned\
+                           sub_versioned
 }
 
 fixture_make_auto_test_dirs() {

--- a/test/auto-node-test.sh
+++ b/test/auto-node-test.sh
@@ -22,11 +22,11 @@ function test_chnode_auto_loaded_in_bash()
 {
 	[[ -n "$BASH_VERSION" ]] || return
 
-	local command=". $PWD/share/chnode/auto.sh && trap -p DEBUG"
+	local command=". ./auto.sh && trap -p DEBUG"
 	local output="$("$SHELL" -c "$command")"
 
 	assertTrue "did not add a trap hook for chnode_auto" \
-		   '[[ "$output" == *chnode_auto* ]]'
+		   "[[ "$output" == *chnode_auto* ]]"
 }
 
 function test_chnode_auto_loaded_twice_in_zsh()

--- a/test/auto-node-test.sh
+++ b/test/auto-node-test.sh
@@ -16,18 +16,16 @@ function test_chnode_auto_loaded_in_zsh()
 		     "$preexec_functions"
 }
 
-# function test_chnode_auto_loaded_in_bash()
-# {
-# 	[[ -n "$BASH_VERSION" ]] || return
+function test_chnode_auto_loaded_in_bash()
+{
+	[[ -n "$BASH_VERSION" ]] || return
 
-# 	local command=". ./auto.sh && trap -p DEBUG"
-# 	local output="$("bash" -c "$command")"
-#   echo $output
-#   echo $("*chnode_auto*")
-#   echo "[[ $output == *chruby_auto* ]]"
-# 	assertTrue "did not add a trap hook for chruby_auto" \
-# 		   "[[ $output == "*chruby_auto*" ]]"
-# }
+	local command=". $PWD/auto.sh && trap -p DEBUG"
+	local output="$("bash" -c "$command")"
+
+	assertTrue "did not add a trap hook for chnode_auto" \
+		   '[[ "$output" == *chnode_auto* ]]'
+}
 
 function test_chnode_auto_loaded_twice_in_zsh()
 {

--- a/test/auto-node-test.sh
+++ b/test/auto-node-test.sh
@@ -5,122 +5,125 @@ source test/setup-default-chnode.sh
 
 function setUp()
 {
-	chruby_reset
-	unset RUBY_AUTO_VERSION
+	chnode_reset
+	unset NODE_AUTO_VERSION
 }
 
-function test_chruby_auto_loaded_in_zsh()
+function test_chnode_auto_loaded_in_zsh()
 {
 	[[ -n "$ZSH_VERSION" ]] || return
 
-	assertEquals "did not add chruby_auto to preexec_functions" \
-		     "chruby_auto" \
+	assertEquals "did not add chnode_auto to preexec_functions" \
+		     "chnode_auto" \
 		     "$preexec_functions"
 }
 
-function test_chruby_auto_loaded_in_bash()
+function test_chnode_auto_loaded_in_bash()
 {
 	[[ -n "$BASH_VERSION" ]] || return
 
-	local command=". $PWD/share/chruby/auto.sh && trap -p DEBUG"
+	local command=". $PWD/share/chnode/auto.sh && trap -p DEBUG"
 	local output="$("$SHELL" -c "$command")"
 
-	assertTrue "did not add a trap hook for chruby_auto" \
-		   '[[ "$output" == *chruby_auto* ]]'
+	assertTrue "did not add a trap hook for chnode_auto" \
+		   '[[ "$output" == *chnode_auto* ]]'
 }
 
-function test_chruby_auto_loaded_twice_in_zsh()
+function test_chnode_auto_loaded_twice_in_zsh()
 {
 	[[ -n "$ZSH_VERSION" ]] || return
-
-	. ./share/chruby/auto.sh
-
-	assertNotEquals "should not add chruby_auto twice" \
+	. ./auto.sh
+	assertNotEquals "should not add chnode_auto twice" \
 		        "$preexec_functions" \
-			"chruby_auto chruby_auto"
+			"chnode_auto chnode_auto"
 }
 
-function test_chruby_auto_loaded_twice()
+function test_chnode_auto_loaded_twice()
 {
-	RUBY_AUTO_VERSION="dirty"
-	PROMPT_COMMAND="chruby_auto"
+	NODE_AUTO_VERSION="dirty"
+	PROMPT_COMMAND="chnode_auto"
 
-	. ./share/chruby/auto.sh
+	. ./auto.sh
 
-	assertNull "RUBY_AUTO_VERSION was not unset" "$RUBY_AUTO_VERSION"
+	assertNull "NODE_AUTO_VERSION was not unset" "$NODE_AUTO_VERSION"
 }
 
-function test_chruby_auto_enter_project_dir()
+function test_chnode_auto_enter_project_dir()
 {
-	cd "$test_project_dir" && chruby_auto
+	cd "$CHNODE_NODES_AUTO_DIR" && chnode_auto
 
-	assertEquals "did not switch Ruby when entering a versioned directory" \
-		     "$test_ruby_root" "$RUBY_ROOT"
+	assertEquals "did not switch node when entering a versioned directory" \
+		     "$test_node_root" "$NODE_ROOT"
 }
 
-function test_chruby_auto_enter_subdir_directly()
+function test_chnode_auto_enter_subdir_directly()
 {
-	cd "$test_project_dir/sub_dir" && chruby_auto
+	cd "$CHNODE_NODES_AUTO_DIR/sub_dir" && chnode_auto
 
-	assertEquals "did not switch Ruby when directly entering a sub-directory of a versioned directory" \
-		     "$test_ruby_root" "$RUBY_ROOT"
+	assertEquals "did not switch node when directly entering a sub-directory of a versioned directory" \
+		     "$test_node_root" "$NODE_ROOT"
 }
 
-function test_chruby_auto_enter_subdir()
+function test_chnode_auto_enter_subdir()
 {
-	cd "$test_project_dir" && chruby_auto
-	cd sub_dir             && chruby_auto
+	cd "$CHNODE_NODES_AUTO_DIR" && chnode_auto
+	cd sub_dir             && chnode_auto
 
-	assertEquals "did not keep the current Ruby when entering a sub-dir" \
-		     "$test_ruby_root" "$RUBY_ROOT"
+	assertEquals "did not keep the current node when entering a sub-dir" \
+		     "$test_node_root" "$NODE_ROOT"
 }
 
-function test_chruby_auto_enter_subdir_with_ruby_version()
+function test_chnode_auto_enter_subdir_with_node_version()
 {
-	cd "$test_project_dir"    && chruby_auto
-	cd sub_versioned/         && chruby_auto
+	cd "$CHNODE_NODES_AUTO_DIR"    && chnode_auto
+	cd sub_versioned/         && chnode_auto
 
-	assertNull "did not switch the Ruby when leaving a sub-versioned directory" \
-		   "$RUBY_ROOT"
+	assertNull "did not switch the node when leaving a sub-versioned directory" \
+		   "$NODE_ROOT"
 }
 
-function test_chruby_auto_modified_ruby_version()
+function test_chnode_auto_modified_node_version()
 {
-	cd "$test_project_dir/modified_version" && chruby_auto
-	echo "2.2" > .ruby-version              && chruby_auto
+	cd "$CHNODE_NODES_AUTO_DIR/modified_version" && chnode_auto
+	echo "node-8.1.0" > .node-version              && chnode_auto
 
-	assertEquals "did not detect the modified .ruby-version file" \
-		     "$test_ruby_root" "$RUBY_ROOT"
+	assertEquals "did not detect the modified .node-version file" \
+		     "$test_node_root" "$NODE_ROOT"
 }
 
-function test_chruby_auto_overriding_ruby_version()
+function test_chnode_auto_overriding_node_version()
 {
-	cd "$test_project_dir" && chruby_auto
-	chruby system          && chruby_auto
+	cd "$CHNODE_NODES_AUTO_DIR" && chnode_auto
+	chnode node-8         && chnode_auto
 
-	assertNull "did not override the Ruby set in .ruby-version" "$RUBY_ROOT"
+	assertNull "did not override the node set in .node-version" "$NODE_ROOT"
 }
 
-function test_chruby_auto_leave_project_dir()
+function test_chnode_auto_leave_project_dir()
 {
-	cd "$test_project_dir"    && chruby_auto
-	cd "$test_project_dir/.." && chruby_auto
+	cd "$CHNODE_NODES_AUTO_DIR"    && chnode_auto
+	cd "$CHNODE_NODES_AUTO_DIR/.." && chnode_auto
 
-	assertNull "did not reset the Ruby when leaving a versioned directory" \
-		   "$RUBY_ROOT"
+	assertNull "did not reset the node when leaving a versioned directory" \
+		   "$NODE_ROOT"
 }
 
-function test_chruby_auto_invalid_ruby_version()
+function test_chnode_auto_invalid_node_version()
 {
-	local expected_auto_version="$(cat $test_project_dir/bad/.ruby-version)"
 
-	cd "$test_project_dir" && chruby_auto
-	cd bad/                && chruby_auto 2>/dev/null
 
-	assertEquals "did not keep the current Ruby when loading an unknown version" \
-		     "$test_ruby_root" "$RUBY_ROOT"
-	assertEquals "did not set RUBY_AUTO_VERSION" \
-		     "$expected_auto_version" "$RUBY_AUTO_VERSION"
+	cd "$CHNODE_NODES_AUTO_DIR/bad/" && chnode_auto
+  touch .node-version  && chnode_auto
+
+
+	cd "$CHNODE_NODES_AUTO_DIR/bad/" && chnode_auto 2>/dev/null
+
+  local expected_auto_version="$(cat $CHNODE_NODES_AUTO_DIR/bad/.node-version)"
+
+	assertEquals "did not keep the current node when loading an unknown version" \
+		     "$test_node_root" "$NODE_ROOT"
+	assertEquals "did not set NODE_AUTO_VERSION" \
+		     "$expected_auto_version" "$NODE_AUTO_VERSION"
 }
 
 function tearDown()

--- a/test/auto-node-test.sh
+++ b/test/auto-node-test.sh
@@ -4,7 +4,7 @@ source test/setup-default-chnode.sh
 function setUp()
 {
 	chnode_reset
-	unset NODE_AUTO_VERSION
+	unset CHNODE_AUTO_VERSION
 }
 
 function test_chnode_auto_loaded_in_zsh()
@@ -44,12 +44,12 @@ function test_chnode_auto_loaded_twice_in_zsh()
 
 function test_chnode_auto_loaded_twice()
 {
-	NODE_AUTO_VERSION="dirty"
+	CHNODE_AUTO_VERSION="dirty"
 	PROMPT_COMMAND="chruby_auto"
 
 	. ./auto.sh
 
-	assertNull "NODE_AUTO_VERSION was not unset" "$NODE_AUTO_VERSION"
+	assertNull "CHNODE_AUTO_VERSION was not unset" "$CHNODE_AUTO_VERSION"
 }
 
 function test_chnode_auto_enter_project_dir()
@@ -85,7 +85,7 @@ function test_chnode_auto_enter_subdir()
 
 function test_chnode_auto_modified_node_version()
 {
-  cd "$CHNODE_NODES_AUTO_DIR/modified_version" && echo "node-11.5.0" > .node-version
+  cd "$CHNODE_NODES_AUTO_DIR/modified_version" && echo "node-10.11.0" > .node-version
 	cd "$CHNODE_NODES_AUTO_DIR/modified_version" && chnode_auto
 	echo "node-8.1.0" > .node-version            && chnode_auto
 
@@ -125,8 +125,8 @@ function test_chnode_auto_invalid_ruby_version()
 
 	assertEquals "did not keep the current Node when loading an unknown version" \
 		     "$test_node_root" "$CHNODE_ROOT"
-	assertEquals "did not set NODE_AUTO_VERSION" \
-		     "$expected_auto_version" "$NODE_AUTO_VERSION"
+	assertEquals "did not set CHNODE_AUTO_VERSION" \
+		     "$expected_auto_version" "$CHNODE_AUTO_VERSION"
 }
 
 SHUNIT_PARENT=$0 source "$SHUNIT2"

--- a/test/auto-node-test.sh
+++ b/test/auto-node-test.sh
@@ -11,6 +11,7 @@ function test_chnode_auto_loaded_in_zsh()
 {
 	[[ -n "$ZSH_VERSION" ]] || return
 
+  # shellcheck disable=SC2154
 	assertEquals "did not add chnode_auto to preexec_functions" \
 		     "chnode_auto" \
 		     "$preexec_functions"
@@ -21,8 +22,11 @@ function test_chnode_auto_loaded_in_bash()
 	[[ -n "$BASH_VERSION" ]] || return
 
 	local command=". $PWD/auto.sh && trap -p DEBUG"
-	local output="$("bash" -c "$command")"
+	local output
+  # shellcheck disable=SC2034
+  output="$("bash" -c "$command")"
 
+  # shellcheck disable=SC2016
 	assertTrue "did not add a trap hook for chnode_auto" \
 		   '[[ "$output" == *chnode_auto* ]]'
 }
@@ -113,7 +117,8 @@ function test_chnode_auto_invalid_ruby_version()
 {
   cd "$CHNODE_NODES_AUTO_DIR" && echo "node-8.1.0" > .node-version
   cd "$CHNODE_NODES_AUTO_DIR/bad" && echo "foo" > .node-version
-	local expected_auto_version="$(cat $CHNODE_NODES_AUTO_DIR/bad/.node-version)"
+	local expected_auto_version
+  expected_auto_version="$(cat "$CHNODE_NODES_AUTO_DIR"/bad/.node-version)"
 
 	cd "$CHNODE_NODES_AUTO_DIR" && chnode_auto
 	cd bad/                     && chnode_auto 2>/dev/null

--- a/test/auto-node-test.sh
+++ b/test/auto-node-test.sh
@@ -118,7 +118,7 @@ function test_chnode_auto_invalid_node_version()
 
 	cd "$CHNODE_NODES_AUTO_DIR/bad/" && chnode_auto 2>/dev/null
 
-  local expected_auto_version="$(cat $CHNODE_NODES_AUTO_DIR/bad/.node-version)"
+  local expected_auto_version="$(cat "$CHNODE_NODES_AUTO_DIR"/bad/.node-version)"
 
 	assertEquals "did not keep the current node when loading an unknown version" \
 		     "$test_node_root" "$NODE_ROOT"
@@ -126,9 +126,4 @@ function test_chnode_auto_invalid_node_version()
 		     "$expected_auto_version" "$NODE_AUTO_VERSION"
 }
 
-function tearDown()
-{
-	cd "$PWD"
-}
-
-SHUNIT_PARENT=$0 . $SHUNIT2
+SHUNIT_PARENT=$0 source "$SHUNIT2"

--- a/test/auto-node-test.sh
+++ b/test/auto-node-test.sh
@@ -1,5 +1,3 @@
-# -*- sh-shell: bash; -*-
-
 source test/setup-shunit2.sh
 source test/setup-default-chnode.sh
 
@@ -18,22 +16,26 @@ function test_chnode_auto_loaded_in_zsh()
 		     "$preexec_functions"
 }
 
-function test_chnode_auto_loaded_in_bash()
-{
-	[[ -n "$BASH_VERSION" ]] || return
+# function test_chnode_auto_loaded_in_bash()
+# {
+# 	[[ -n "$BASH_VERSION" ]] || return
 
-	local command=". ./auto.sh && trap -p DEBUG"
-	local output="$("$SHELL" -c "$command")"
-
-	assertTrue "did not add a trap hook for chnode_auto" \
-		   "[[ "$output" == *chnode_auto* ]]"
-}
+# 	local command=". ./auto.sh && trap -p DEBUG"
+# 	local output="$("bash" -c "$command")"
+#   echo $output
+#   echo $("*chnode_auto*")
+#   echo "[[ $output == *chruby_auto* ]]"
+# 	assertTrue "did not add a trap hook for chruby_auto" \
+# 		   "[[ $output == "*chruby_auto*" ]]"
+# }
 
 function test_chnode_auto_loaded_twice_in_zsh()
 {
 	[[ -n "$ZSH_VERSION" ]] || return
+
 	. ./auto.sh
-	assertNotEquals "should not add chnode_auto twice" \
+
+	assertNotEquals "should not add chruby_auto twice" \
 		        "$preexec_functions" \
 			"chnode_auto chnode_auto"
 }
@@ -41,7 +43,7 @@ function test_chnode_auto_loaded_twice_in_zsh()
 function test_chnode_auto_loaded_twice()
 {
 	NODE_AUTO_VERSION="dirty"
-	PROMPT_COMMAND="chnode_auto"
+	PROMPT_COMMAND="chruby_auto"
 
 	. ./auto.sh
 
@@ -50,78 +52,76 @@ function test_chnode_auto_loaded_twice()
 
 function test_chnode_auto_enter_project_dir()
 {
+  cd "$CHNODE_NODES_AUTO_DIR" && echo "node-8.1.0" > .node-version
 	cd "$CHNODE_NODES_AUTO_DIR" && chnode_auto
 
-	assertEquals "did not switch node when entering a versioned directory" \
-		     "$test_node_root" "$NODE_ROOT"
+
+	assertEquals "did not switch Node when entering a versioned directory" \
+		     "$test_node_root" "$CHNODE_ROOT"
 }
 
 function test_chnode_auto_enter_subdir_directly()
 {
+  cd "$CHNODE_NODES_AUTO_DIR" && echo "node-8.1.0" > .node-version
+  cd "$CHNODE_NODES_AUTO_DIR" && chnode_auto
 	cd "$CHNODE_NODES_AUTO_DIR/sub_dir" && chnode_auto
 
-	assertEquals "did not switch node when directly entering a sub-directory of a versioned directory" \
-		     "$test_node_root" "$NODE_ROOT"
+
+	assertEquals "did not switch Node when directly entering a sub-directory of a versioned directory" \
+		     "$test_node_root" "$CHNODE_ROOT"
 }
 
 function test_chnode_auto_enter_subdir()
 {
+  cd "$CHNODE_NODES_AUTO_DIR" && echo "node-8.1.0" > .node-version
 	cd "$CHNODE_NODES_AUTO_DIR" && chnode_auto
-	cd sub_dir             && chnode_auto
+	cd sub_dir                  && chnode_auto
 
-	assertEquals "did not keep the current node when entering a sub-dir" \
-		     "$test_node_root" "$NODE_ROOT"
-}
-
-function test_chnode_auto_enter_subdir_with_node_version()
-{
-	cd "$CHNODE_NODES_AUTO_DIR"    && chnode_auto
-	cd sub_versioned/         && chnode_auto
-
-	assertNull "did not switch the node when leaving a sub-versioned directory" \
-		   "$NODE_ROOT"
+	assertEquals "did not keep the current Node when entering a sub-dir" \
+		     "$test_node_root" "$CHNODE_ROOT"
 }
 
 function test_chnode_auto_modified_node_version()
 {
+  cd "$CHNODE_NODES_AUTO_DIR/modified_version" && echo "node-11.5.0" > .node-version
 	cd "$CHNODE_NODES_AUTO_DIR/modified_version" && chnode_auto
-	echo "node-8.1.0" > .node-version              && chnode_auto
+	echo "node-8.1.0" > .node-version            && chnode_auto
 
 	assertEquals "did not detect the modified .node-version file" \
-		     "$test_node_root" "$NODE_ROOT"
+		     "$test_node_root" "$CHNODE_ROOT"
 }
 
-function test_chnode_auto_overriding_node_version()
+function test_chnode_auto_no_override_manual()
 {
+  cd "$CHNODE_NODES_AUTO_DIR" && echo "node-8.1.0" > .node-version
 	cd "$CHNODE_NODES_AUTO_DIR" && chnode_auto
-	chnode node-8         && chnode_auto
+	chnode node-10          && chnode_auto
 
-	assertNull "did not override the node set in .node-version" "$NODE_ROOT"
+	assertEquals "did not override the Node set in .node-version"\
+        "$CHNODE_NODES_DIR/node-10.11.0" "$CHNODE_ROOT"
 }
 
 function test_chnode_auto_leave_project_dir()
 {
+  cd "$CHNODE_NODES_AUTO_DIR" && echo "node-8.1.0" > .node-version
 	cd "$CHNODE_NODES_AUTO_DIR"    && chnode_auto
 	cd "$CHNODE_NODES_AUTO_DIR/.." && chnode_auto
 
-	assertNull "did not reset the node when leaving a versioned directory" \
-		   "$NODE_ROOT"
+	assertNull "did not reset the Node when leaving a versioned directory" \
+		   "$CHNODE_ROOT"
 }
 
-function test_chnode_auto_invalid_node_version()
+function test_chnode_auto_invalid_ruby_version()
 {
+  cd "$CHNODE_NODES_AUTO_DIR" && echo "node-8.1.0" > .node-version
+  cd "$CHNODE_NODES_AUTO_DIR/bad" && echo "foo" > .node-version
+	local expected_auto_version="$(cat $CHNODE_NODES_AUTO_DIR/bad/.node-version)"
 
+	cd "$CHNODE_NODES_AUTO_DIR" && chnode_auto
+	cd bad/                     && chnode_auto 2>/dev/null
 
-	cd "$CHNODE_NODES_AUTO_DIR/bad/" && chnode_auto
-  touch .node-version  && chnode_auto
-
-
-	cd "$CHNODE_NODES_AUTO_DIR/bad/" && chnode_auto 2>/dev/null
-
-  local expected_auto_version="$(cat "$CHNODE_NODES_AUTO_DIR"/bad/.node-version)"
-
-	assertEquals "did not keep the current node when loading an unknown version" \
-		     "$test_node_root" "$NODE_ROOT"
+	assertEquals "did not keep the current Node when loading an unknown version" \
+		     "$test_node_root" "$CHNODE_ROOT"
 	assertEquals "did not set NODE_AUTO_VERSION" \
 		     "$expected_auto_version" "$NODE_AUTO_VERSION"
 }

--- a/test/auto-node-test.sh
+++ b/test/auto-node-test.sh
@@ -1,5 +1,6 @@
 source test/setup-shunit2.sh
 source test/setup-default-chnode.sh
+source test/setup-default-auto.sh
 
 function setUp()
 {

--- a/test/auto-node-test.sh
+++ b/test/auto-node-test.sh
@@ -1,0 +1,131 @@
+# -*- sh-shell: bash; -*-
+
+source test/setup-shunit2.sh
+source test/setup-default-chnode.sh
+
+function setUp()
+{
+	chruby_reset
+	unset RUBY_AUTO_VERSION
+}
+
+function test_chruby_auto_loaded_in_zsh()
+{
+	[[ -n "$ZSH_VERSION" ]] || return
+
+	assertEquals "did not add chruby_auto to preexec_functions" \
+		     "chruby_auto" \
+		     "$preexec_functions"
+}
+
+function test_chruby_auto_loaded_in_bash()
+{
+	[[ -n "$BASH_VERSION" ]] || return
+
+	local command=". $PWD/share/chruby/auto.sh && trap -p DEBUG"
+	local output="$("$SHELL" -c "$command")"
+
+	assertTrue "did not add a trap hook for chruby_auto" \
+		   '[[ "$output" == *chruby_auto* ]]'
+}
+
+function test_chruby_auto_loaded_twice_in_zsh()
+{
+	[[ -n "$ZSH_VERSION" ]] || return
+
+	. ./share/chruby/auto.sh
+
+	assertNotEquals "should not add chruby_auto twice" \
+		        "$preexec_functions" \
+			"chruby_auto chruby_auto"
+}
+
+function test_chruby_auto_loaded_twice()
+{
+	RUBY_AUTO_VERSION="dirty"
+	PROMPT_COMMAND="chruby_auto"
+
+	. ./share/chruby/auto.sh
+
+	assertNull "RUBY_AUTO_VERSION was not unset" "$RUBY_AUTO_VERSION"
+}
+
+function test_chruby_auto_enter_project_dir()
+{
+	cd "$test_project_dir" && chruby_auto
+
+	assertEquals "did not switch Ruby when entering a versioned directory" \
+		     "$test_ruby_root" "$RUBY_ROOT"
+}
+
+function test_chruby_auto_enter_subdir_directly()
+{
+	cd "$test_project_dir/sub_dir" && chruby_auto
+
+	assertEquals "did not switch Ruby when directly entering a sub-directory of a versioned directory" \
+		     "$test_ruby_root" "$RUBY_ROOT"
+}
+
+function test_chruby_auto_enter_subdir()
+{
+	cd "$test_project_dir" && chruby_auto
+	cd sub_dir             && chruby_auto
+
+	assertEquals "did not keep the current Ruby when entering a sub-dir" \
+		     "$test_ruby_root" "$RUBY_ROOT"
+}
+
+function test_chruby_auto_enter_subdir_with_ruby_version()
+{
+	cd "$test_project_dir"    && chruby_auto
+	cd sub_versioned/         && chruby_auto
+
+	assertNull "did not switch the Ruby when leaving a sub-versioned directory" \
+		   "$RUBY_ROOT"
+}
+
+function test_chruby_auto_modified_ruby_version()
+{
+	cd "$test_project_dir/modified_version" && chruby_auto
+	echo "2.2" > .ruby-version              && chruby_auto
+
+	assertEquals "did not detect the modified .ruby-version file" \
+		     "$test_ruby_root" "$RUBY_ROOT"
+}
+
+function test_chruby_auto_overriding_ruby_version()
+{
+	cd "$test_project_dir" && chruby_auto
+	chruby system          && chruby_auto
+
+	assertNull "did not override the Ruby set in .ruby-version" "$RUBY_ROOT"
+}
+
+function test_chruby_auto_leave_project_dir()
+{
+	cd "$test_project_dir"    && chruby_auto
+	cd "$test_project_dir/.." && chruby_auto
+
+	assertNull "did not reset the Ruby when leaving a versioned directory" \
+		   "$RUBY_ROOT"
+}
+
+function test_chruby_auto_invalid_ruby_version()
+{
+	local expected_auto_version="$(cat $test_project_dir/bad/.ruby-version)"
+
+	cd "$test_project_dir" && chruby_auto
+	cd bad/                && chruby_auto 2>/dev/null
+
+	assertEquals "did not keep the current Ruby when loading an unknown version" \
+		     "$test_ruby_root" "$RUBY_ROOT"
+	assertEquals "did not set RUBY_AUTO_VERSION" \
+		     "$expected_auto_version" "$RUBY_AUTO_VERSION"
+}
+
+function tearDown()
+{
+	cd "$PWD"
+}
+
+SHUNIT_PARENT=$0 . $SHUNIT2

--- a/test/setup-default-auto.sh
+++ b/test/setup-default-auto.sh
@@ -1,0 +1,18 @@
+# -*- sh-shell: bash; -*-
+
+source support/fixture.sh
+
+fixture_make_default_auto_dir
+CHNODE_NODES_AUTO_DIR=$__FIXTURE_DEFAULT_AUTO_DIR
+fixture_make_default_auto_test_dirs "$CHNODE_NODES_AUTO_DIR"
+
+source auto.sh
+
+# shellcheck disable=SC2034
+__ORG_CHNODE_NODES=("${CHNODE_NODES[@]}")
+
+export test_node_root="$CHNODE_NODES_DIR/node-8.1.0"
+
+oneTimeTearDown() {
+    fixture_delete_default_auto_dir
+}

--- a/test/setup-default-chnode.sh
+++ b/test/setup-default-chnode.sh
@@ -6,7 +6,6 @@ fixture_make_default_dir
 CHNODE_NODES_DIR=$__FIXTURE_DEFAULT_DIR
 fixture_make_default_nodes "$CHNODE_NODES_DIR"
 
-
 source chnode.sh
 
 # shellcheck disable=SC2034

--- a/test/setup-default-chnode.sh
+++ b/test/setup-default-chnode.sh
@@ -14,7 +14,7 @@ source auto.sh
 # shellcheck disable=SC2034
 __ORG_CHNODE_NODES=("${CHNODE_NODES[@]}")
 
-test_node_root="$CHNODE_NODES_DIR/node-8.1.0"
+export test_node_root="$CHNODE_NODES_DIR/node-8.1.0"
 
 oneTimeTearDown() {
     fixture_delete_default_dir

--- a/test/setup-default-chnode.sh
+++ b/test/setup-default-chnode.sh
@@ -14,6 +14,8 @@ source auto.sh
 # shellcheck disable=SC2034
 __ORG_CHNODE_NODES=("${CHNODE_NODES[@]}")
 
+test_node_root="$CHNODE_NODES_DIR/node-8.1.0"
+
 oneTimeTearDown() {
     fixture_delete_default_dir
 }

--- a/test/setup-default-chnode.sh
+++ b/test/setup-default-chnode.sh
@@ -4,17 +4,13 @@ source support/fixture.sh
 
 fixture_make_default_dir
 CHNODE_NODES_DIR=$__FIXTURE_DEFAULT_DIR
-CHNODE_NODES_AUTO_DIR=$__FIXTURE_DEFAULT_AUTO_DIR
 fixture_make_default_nodes "$CHNODE_NODES_DIR"
-fixture_make_default_auto_test_dirs "$CHNODE_NODES_AUTO_DIR"
+
 
 source chnode.sh
-source auto.sh
 
 # shellcheck disable=SC2034
 __ORG_CHNODE_NODES=("${CHNODE_NODES[@]}")
-
-export test_node_root="$CHNODE_NODES_DIR/node-8.1.0"
 
 oneTimeTearDown() {
     fixture_delete_default_dir

--- a/test/setup-default-chnode.sh
+++ b/test/setup-default-chnode.sh
@@ -4,9 +4,12 @@ source support/fixture.sh
 
 fixture_make_default_dir
 CHNODE_NODES_DIR=$__FIXTURE_DEFAULT_DIR
+CHNODE_NODES_AUTO_DIR=$__FIXTURE_DEFAULT_AUTO_DIR
 fixture_make_default_nodes "$CHNODE_NODES_DIR"
+fixture_make_default_auto_test_dirs "$CHNODE_NODES_AUTO_DIR"
 
 source chnode.sh
+source auto.sh
 
 # shellcheck disable=SC2034
 __ORG_CHNODE_NODES=("${CHNODE_NODES[@]}")


### PR DESCRIPTION
Ok Take 2.

Using the logic from chruby as a guide I worked out an auto.sh script for this project.

Now when the auto.sh script is sourced, it looks for a .node-version file in your current directory and up and uses that to set the node version using the chnode script.

* Adds auto.sh script to allow version switching
* Adds tests for auto.sh
* Adds test fixtures for auto.sh, keeping them separated out on their own.
* Updates makefile to install auto.sh
* Adds relevant information to README